### PR TITLE
Override JSON or Create a new one based on Path

### DIFF
--- a/typs/jsonObject/json_object_test.go
+++ b/typs/jsonObject/json_object_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/techrail/ground/typs/appError"
@@ -2061,7 +2062,7 @@ func TestOverrideObjectWithArray(t *testing.T) {
 	}
 }
 
-// Scenario 4: Create non-existing continous array
+// Scenario 4: Create a non-existing continuous array
 func TestCreateNonExistingContinuosArray(t *testing.T) {
 	jsonObj, _ := ToJsonObject(jsonString)
 	json, err := SetValueAndOverrideInJsonObjectByJPath(jsonObj, "obj.nestedObj.[3].[3].[3]", 10.01, true)
@@ -2074,6 +2075,24 @@ func TestCreateNonExistingContinuosArray(t *testing.T) {
 	}
 	if value != 10.01 {
 		t.Error("Incorrect value of nonexisting object")
-		t.Fail()
 	}
+}
+
+// Scenario 5: Complex non existing path
+func TestComplexNonExistingPath(t *testing.T) {
+	jsonObj, _ := ToJsonObject(jsonString)
+	// fmt.Println("Before:", jsonObj.PrettyString())
+	json, err := SetValueAndOverrideInJsonObjectByJPath(jsonObj, "obj.somenewObj.somearr.[3].someNewObj.anotherArr.[8].field", "hello", true)
+	if err != nil {
+		t.Error("Failed to set value of nonexisting object", err)
+	}
+	_, value, appErr := json.GetValueFromJsonObjectByJPath("obj.somenewObj.somearr.[3].someNewObj.anotherArr.[8].field")
+	if !appErr.IsBlank() {
+		t.Error("Failed to get value of nonexisting object", appErr)
+	}
+	result := strings.TrimSpace(fmt.Sprint(value))
+	if strings.EqualFold("put this value here", result) {
+		t.Error("Incorrect value of nonexisting object")
+	}
+	// fmt.Println("After:", jsonObj.PrettyString())
 }

--- a/typs/jsonObject/json_object_test.go
+++ b/typs/jsonObject/json_object_test.go
@@ -2011,3 +2011,16 @@ func TestSetValueInJsonObjectByJPath(t *testing.T) {
 		}
 	}
 }
+
+func TestSetValueAndOverrideInJsonObjectByJPath(t *testing.T) {
+	json, err := ToJsonObject(jsonString)
+	if err != nil {
+		fmt.Println("Failed to load JSON object")
+	}
+	fmt.Printf("Before value:\n %s\n", json.String())
+	json, err = SetValueAndOverrideInJsonObjectByJPath(json, "obj.nestedObj.child0.key1.key2.key3", "Hurrah!", true)
+	if err != nil {
+		fmt.Println("Failed to set value", err)
+	}
+	fmt.Printf("After value:\n %s\n", json.String())
+}

--- a/typs/jsonObject/json_object_test.go
+++ b/typs/jsonObject/json_object_test.go
@@ -104,6 +104,7 @@ var jsonString = `
   }
 }
 `
+var jsonObj Typ
 
 // getTestsSuccessful indicates if the TestGetValueFromJsonObjectByJPath encountered no errors
 //
@@ -2012,15 +2013,67 @@ func TestSetValueInJsonObjectByJPath(t *testing.T) {
 	}
 }
 
-func TestSetValueAndOverrideInJsonObjectByJPath(t *testing.T) {
-	json, err := ToJsonObject(jsonString)
+// Scenarios 1: Non existing object path
+func TestCreateNonExistingObject(t *testing.T) {
+	jsonObj, _ := ToJsonObject(jsonString)
+	json, err := SetValueAndOverrideInJsonObjectByJPath(jsonObj, "obj.noneixistent.key1.key2.kye3.key4.key5", 2, true)
 	if err != nil {
-		fmt.Println("Failed to load JSON object")
+		t.Error("E#1P9WMG - Failed to set value of nonexisting object", err)
 	}
-	fmt.Printf("Before value:\n %s\n", json.String())
-	json, err = SetValueAndOverrideInJsonObjectByJPath(json, "obj.nestedObj.child0.key1.key2.key3", "Hurrah!", true)
+	_, value, appErr := json.GetValueFromJsonObjectByJPath("obj.noneixistent.key1.key2.kye3.key4.key5")
+	if !appErr.IsBlank() {
+		t.Error("E#1P9WMO - Failed to get value of nonexisting object", err)
+	}
+	if value != 2 {
+		t.Error("E#1P9WMT - Incorrect value of nonexisting object")
+	}
+}
+
+// Scenario 2: Non existing object with Array
+func TestCreateNonExistingObjectWithArray(t *testing.T) {
+	jsonObj, _ := ToJsonObject(jsonString)
+	json, err := SetValueAndOverrideInJsonObjectByJPath(jsonObj, "obj.noneixistent.key1.[1]", 10.00, true)
 	if err != nil {
-		fmt.Println("Failed to set value", err)
+		t.Error("E#1P9WN7 - Failed to set value of nonexisting object", err)
 	}
-	fmt.Printf("After value:\n %s\n", json.String())
+	_, value, appErr := json.GetValueFromJsonObjectByJPath("obj.noneixistent.key1.[1]")
+	if !appErr.IsBlank() {
+		t.Error("E#1P9WNC - Failed to get value of nonexisting object", appErr)
+	}
+	if value != 10.00 {
+		t.Error("E#1P9WNJ - Incorrect value of nonexisting object")
+	}
+}
+
+// Scenario 3: Override object with array
+func TestOverrideObjectWithArray(t *testing.T) {
+	jsonObj, _ := ToJsonObject(jsonString)
+	json, err := SetValueAndOverrideInJsonObjectByJPath(jsonObj, "obj.nestedObj.[1]", 10.01, true)
+	if err != nil {
+		t.Error("E#1P9WNX - Failed to set value of nonexisting object", err)
+	}
+	_, value, appErr := json.GetValueFromJsonObjectByJPath("obj.nestedObj.[1]")
+	if !appErr.IsBlank() {
+		t.Error("E#1P9WO3 - Failed to get value of nonexisting object", appErr)
+	}
+	if value != 10.01 {
+		t.Error("E#1P9WO9 - Incorrect value of nonexisting object")
+	}
+}
+
+// Scenario 4: Create non-existing continous array
+func TestCreateNonExistingContinuosArray(t *testing.T) {
+	jsonObj, _ := ToJsonObject(jsonString)
+	json, err := SetValueAndOverrideInJsonObjectByJPath(jsonObj, "obj.nestedObj.[3].[3].[3]", 10.01, true)
+	if err != nil {
+		t.Error("Failed to set value of nonexisting object", err)
+	}
+	_, value, appErr := json.GetValueFromJsonObjectByJPath("obj.nestedObj.[3].[3].[3]")
+	if !appErr.IsBlank() {
+		t.Error("Failed to get value of nonexisting object", appErr)
+	}
+	if value != 10.01 {
+		t.Error("Incorrect value of nonexisting object")
+		t.Fail()
+	}
 }


### PR DESCRIPTION
Summary:
- This PR contains code to allow the user to specify non-existing keys, in the path of the `SetValueAndOverrideInJsonObjectByJPath`  that will create the path, and set the value.
- The above method will override if there's an object already existing path as specified by the user.
- The existing method `SetValueInJsonObjectByJPath` has its functionality intact.

Key Scenarios that'll be supported by this change (there were a lot of other scenarios that I could think of but I think the below capture the below are the key ones):
- Scenario 1: Non-existing object path
- Scenario 2: Non-existing object with Array
- Scenario 3: Override object with array
- Scenario 4: Create a non-existing continuous array

Results for the existing test, and the new ones passing:
![image](https://github.com/techrail/ground/assets/24785679/d2cc46ec-9fb3-427a-94ef-984ff05efc9f)
