### PR TITLE
fixes #13 - duplicate function name

### DIFF
--- a/dbCodegen/table_base_funcs_gen.go
+++ b/dbCodegen/table_base_funcs_gen.go
@@ -56,7 +56,8 @@ func (g *Generator) buildTableBaseFuncs(table DbTable, importList []string) (str
 
 	// Reverse references
 	for _, rFkey := range table.RevFKeyMap {
-		tabSingleFkeyMethod, iList := g.buildSingleTableRevFkeyFunc(table, rFkey, importList, len(table.RevFKeyMap) > 1)
+
+		tabSingleFkeyMethod, iList := g.buildSingleTableRevFkeyFunc(table, rFkey, importList, hasMultipleKeys(table.RevFKeyMap, rFkey))
 		tabFwdForeignKeyMethods += tabSingleFkeyMethod + "\n\n"
 		importList = iList
 	}
@@ -76,6 +77,15 @@ func (g *Generator) buildTableBaseFuncs(table DbTable, importList []string) (str
 		tableUpdateByIndexes + tableDeleteFuncStr + tableUpsertFuncStr + tabFwdForeignKeyMethods +
 		tableMethodAndDaoSeparator + tableDaoStructAndNew + tableDaoFunctions
 	return tableBaseFuncStr, importList
+}
+
+func hasMultipleKeys(revKeyMap map[string]DbRevFkInfo, key DbRevFkInfo) bool {
+	for _, k := range revKeyMap {
+		if k.ToSchema == key.ToSchema && k.ToTable == key.ToTable && key.ConstraintName != k.ConstraintName {
+			return true
+		}
+	}
+	return false
 }
 
 func (g *Generator) buildTableBaseValidation(table DbTable, importList []string) (string, []string) {

--- a/dbCodegen/table_base_funcs_gen.go
+++ b/dbCodegen/table_base_funcs_gen.go
@@ -50,9 +50,6 @@ func (g *Generator) buildTableBaseFuncs(table DbTable, importList []string) (str
 	// Forward references
 	for _, fkey := range table.FKeyMap {
 		tabSingleFkeyMethod, iList := g.buildSingleTableFwdFkeyFunc(table, fkey, importList)
-		if strings.Contains(tabFwdForeignKeyMethods, strings.Split(tabSingleFkeyMethod, "\n")[0]) {
-			continue
-		}
 		tabFwdForeignKeyMethods += tabSingleFkeyMethod + "\n\n"
 		importList = iList
 	}
@@ -60,9 +57,6 @@ func (g *Generator) buildTableBaseFuncs(table DbTable, importList []string) (str
 	// Reverse references
 	for _, rFkey := range table.RevFKeyMap {
 		tabSingleFkeyMethod, iList := g.buildSingleTableRevFkeyFunc(table, rFkey, importList)
-		if strings.Contains(tabFwdForeignKeyMethods, strings.Split(tabSingleFkeyMethod, "\n")[0]) {
-			continue
-		}
 		tabFwdForeignKeyMethods += tabSingleFkeyMethod + "\n\n"
 		importList = iList
 	}
@@ -823,7 +817,7 @@ func (g *Generator) buildSingleTableRevFkeyFunc(table DbTable, rFkey DbRevFkInfo
 				fromColName, table.Name, table.Schema))
 		}
 
-		funcNamePart += fromCol.GoName
+		funcNamePart += getGoName(fromColName)
 		queryValPairs = append(queryValPairs, fmt.Sprintf("%v = $%v", fromColName, i))
 		i += 1
 		if fromCol.Nullable && fromCol.GoDataType != "any" {

--- a/dbCodegen/table_base_funcs_gen.go
+++ b/dbCodegen/table_base_funcs_gen.go
@@ -50,6 +50,9 @@ func (g *Generator) buildTableBaseFuncs(table DbTable, importList []string) (str
 	// Forward references
 	for _, fkey := range table.FKeyMap {
 		tabSingleFkeyMethod, iList := g.buildSingleTableFwdFkeyFunc(table, fkey, importList)
+		if strings.Contains(tabFwdForeignKeyMethods, strings.Split(tabSingleFkeyMethod, "\n")[0]) {
+			continue
+		}
 		tabFwdForeignKeyMethods += tabSingleFkeyMethod + "\n\n"
 		importList = iList
 	}
@@ -57,6 +60,9 @@ func (g *Generator) buildTableBaseFuncs(table DbTable, importList []string) (str
 	// Reverse references
 	for _, rFkey := range table.RevFKeyMap {
 		tabSingleFkeyMethod, iList := g.buildSingleTableRevFkeyFunc(table, rFkey, importList)
+		if strings.Contains(tabFwdForeignKeyMethods, strings.Split(tabSingleFkeyMethod, "\n")[0]) {
+			continue
+		}
 		tabFwdForeignKeyMethods += tabSingleFkeyMethod + "\n\n"
 		importList = iList
 	}


### PR DESCRIPTION
![image](https://github.com/techrail/ground/assets/24785679/6024b62f-2f21-4781-beef-7c144a4d026d)
A simple one-line change from `fromCol.GoName` to `getGoName(fromColName)`. The fromCol is referencing the current db column, but we want the referenced db column name which can be obtained from `fromColName`. I think the variable name for `fromCol` might be named wrong but it could be correct as well for how it's used later or before in the code.

But for generating the function name, the name of the other column seems more correct.

### Schema used to reproduce the issue and test the fix.

```sql
CREATE TABLE public.users (
    id SERIAL PRIMARY KEY,
    username VARCHAR(255) NOT NULL
);
CREATE TABLE public.followers (
    id SERIAL PRIMARY KEY,
    follower_id INT NOT NULL,
    following_id INT NOT NULL,
    FOREIGN KEY (follower_id) REFERENCES public.users(id),
    FOREIGN KEY (following_id) REFERENCES public.users(id)
);

```
### Before Results
![image](https://github.com/techrail/ground/assets/24785679/dcfc128d-008f-4414-99f5-0e99dc2b5a59)
![image](https://github.com/techrail/ground/assets/24785679/18ba91f8-8220-4e66-b7c2-337f49ed27e6)

### After Results
![image](https://github.com/techrail/ground/assets/24785679/74c3ad61-2ea6-4be0-b621-2c858d8cdcc8)
![image](https://github.com/techrail/ground/assets/24785679/3b1d006e-8e94-475f-a378-28eb8ba7e85f)

Fixes #13 
